### PR TITLE
Code changes to run RAGTest on a GCP Compute Engine

### DIFF
--- a/library/gmail.py
+++ b/library/gmail.py
@@ -98,7 +98,7 @@ class Gmail(GmailServiceProvider):
                 creds.refresh(Request())
             else:
                 flow = InstalledAppFlow.from_client_secrets_file(self.creds, self.SCOPES)
-                creds = flow.run_local_server(port=0)
+                creds = flow.run_local_server(port=3000)
             # save the credentials for the next run
             with open("token.pickle", "wb") as token:
                 pickle.dump(creds, token)


### PR DESCRIPTION
**Update OAuth Port in Gmail Authentication to Support Static Redirect URL on GCP**

**Documents**:

1. [Installation Requirements for RAGTest](https://docs.google.com/document/d/1et7VEOsqJqwxrGElejCrDnvdXhPGHa8TM0ENPKxNAJY/edit?usp=drive_link)
2. [Running RAGTest on Google Cloud Platform (GCP)](https://docs.google.com/document/d/1SIWa3kX9xAa1dYMq9ca-bMQzQJ_XDqAg5jC8I3EIn_U/edit?usp=sharing)



**Purpose of Change:** The modification from a dynamic port assignment (port=0) to a static port (port=3000) during the OAuth flow is to align the authentication process with Google Cloud Platform (GCP) Compute Engine's requirements for specified authorized redirect URLs.

<img width="632" alt="Screenshot 2024-04-18 at 4 02 19 PM" src="https://github.com/knordstrom/RAGTest/assets/122115166/7bce7c38-ed52-41af-8bf3-c008f86a6cf1">


**Background:** In the original code, the Gmail API authentication used flow.run_local_server(port=0), which allows the system to select an available port randomly for the OAuth callback. This dynamic port selection can complicate configurations on cloud platforms like GCP where a consistent and predefined redirect URI is required for security and configuration management.

**Specific Changes Made:** Changed the OAuth callback port from 0 to 3000. This ensures that the OAuth flow always redirects to http://localhost:3000/, which can be consistently registered as an authorized redirect URI in the Google Cloud Console.
This change was implemented in the __authenticate function, where the InstalledAppFlow object initiates the local server with the specified port.

```
flow = InstalledAppFlow.from_client_secrets_file(self.creds, self.SCOPES)
# Original line: creds = flow.run_local_server(port=0)
creds = flow.run_local_server(port=3000)  # Updated to use a static port
```